### PR TITLE
Roles & Lobbies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,4 +105,4 @@ jobs:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           username: ei Noah
           avatar-url: https://cdn.discordapp.com/avatars/730913870805336195/693419adb85f1416a0ec91d09864f1e4.png?size=256
-          content: ${{ env.BODY }}
+          content: \**${{ env.SUBJECT }}**\n${{ env.BODY }}

--- a/src/EiNoah.ts
+++ b/src/EiNoah.ts
@@ -1,5 +1,5 @@
 import {
-  Client, User as DiscordUser, TextChannel, NewsChannel,
+  Client, User as DiscordUser, TextChannel, NewsChannel, Role,
 } from 'discord.js';
 import { createConnection } from 'typeorm';
 import Router, { Handler, messageParser } from './Router';
@@ -26,6 +26,7 @@ class EiNoah {
 
   // this.use wordt doorgepaast aan de echte router
   public use(route: typeof DiscordUser, using: Handler) : void
+  public use(route: typeof Role, using: Handler) : void
   public use(route : string, using: Router | Handler) : void
   public use(route : any, using: any) : any {
     this.router.use(route, using);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import dotenv from 'dotenv';
 import 'reflect-metadata';
 import { User, Role } from 'discord.js';
-import { messageParser } from 'Router';
 import EiNoah from './EiNoah';
 import LobbyRouter from './routes/LobbyRouter';
 import Counter from './routes/Counter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import 'reflect-metadata';
-import { User } from 'discord.js';
+import { User, Role } from 'discord.js';
+import { messageParser } from 'Router';
 import EiNoah from './EiNoah';
 import LobbyRouter from './routes/LobbyRouter';
 import Counter from './routes/Counter';
@@ -20,6 +21,10 @@ eiNoah.use('steek', (routeInfo) => {
   } else {
     routeInfo.msg.channel.send('Lekker');
   }
+});
+
+eiNoah.use(Role, ({ msg, params }) => {
+  msg.channel.send(`${params[0]}s zijn gamers`);
 });
 
 // Als een mention als parameter is gebruikt wordt deze functie aangeroepen,

--- a/src/routes/LobbyRouter.ts
+++ b/src/routes/LobbyRouter.ts
@@ -466,7 +466,7 @@ const helpHanlder : Handler = ({ msg }) => {
   message += '\n`ei lobby create [@mention ...]`: Maak een lobby aan en laat alleen de toegestaande mensen joinen';
   message += '\n`ei lobby create [@mention ...] -nospeak`: Iedereen mag joinen, maar alleen toegestaande mensen mogen spreken';
   message += '\n`ei lobby add @mention ...`: Laat user(s) toe aan de lobby';
-  message += '\n`ei lobby remove [@user ...]`: Verwijder user(s) uit de lobby';
+  message += '\n`ei lobby remove [@mention ...]`: Verwijder user(s)/ role(s) uit de lobby';
   message += '\n`ei lobby type [nospeak/ nojoin]`: Verander het type van de lobby';
   message += '\n`*Admin* ei lobby category true/ false`: Sta users toe lobbies aan te maken in deze categorie';
   message += '\n`*Admin* ei lobby bitrate <8000 - 128000>`: Stel in welke bitrate de lobbies hebben wanneer ze worden aangemaakt';

--- a/src/routes/LobbyRouter.ts
+++ b/src/routes/LobbyRouter.ts
@@ -26,7 +26,7 @@ interface TempChannelOptions {
 }
 
 function generateLobbyName(muted : boolean, owner : DiscordUser) {
-  return `${muted ? '🔇' : '🔉'} ${owner.username}'s Lobby`;
+  return `${muted ? '🔇' : '🔐'} ${owner.username}'s Lobby`;
 }
 
 async function createTempChannel(

--- a/src/routes/LobbyRouter.ts
+++ b/src/routes/LobbyRouter.ts
@@ -186,22 +186,22 @@ router.use('add', async ({ params, msg, guildUser }) => {
   const allowedUsers : Array<DiscordUser | Role> = [];
   const alreadyAllowedUsers : Array<DiscordUser | Role> = [];
 
-  userOrRole.forEach((user) => {
-    if (activeChannel.permissionOverwrites.some((o) => user.id === o.id)) {
-      alreadyAllowedUsers.push(user);
+  userOrRole.forEach((uOrR) => {
+    if (activeChannel.permissionOverwrites.some((o) => uOrR.id === o.id)) {
+      alreadyAllowedUsers.push(uOrR);
     } else {
-      activeChannel.updateOverwrite(user, {
+      activeChannel.updateOverwrite(uOrR, {
         CONNECT: true,
         SPEAK: true,
       });
 
-      allowedUsers.push(user);
+      allowedUsers.push(uOrR);
 
-      if (user instanceof DiscordUser) {
-        activeChannel.members.get(user.id)?.voice.setMute(false);
+      if (uOrR instanceof DiscordUser) {
+        activeChannel.members.get(uOrR.id)?.voice.setMute(false);
       } else {
         activeChannel.members
-          .each((member) => { if (user.members.has(member.id)) member.voice.setMute(false); });
+          .each((member) => { if (uOrR.members.has(member.id)) member.voice.setMute(false); });
       }
     }
   });


### PR DESCRIPTION
Toegevoegd: Rollen kunnen nu gebruikt worden bij: aanmaken van lobbies, toelaten aan lobbies en verwijderen uit lobbies
> De mensen die in de lobby zitten door een rol en die rol wordt verwijderd van de lobby, zullen deze mensen de permission krijgen om in de lobby te blijven en worden ze niet verwijderd

Veranderd: Om meer duidelijkheid te geven wat het type van de lobby is, veranderd het icoontje van een *nojoin* lobby van  `🔉` naar `🔐`