### PR TITLE
ei Noah Pakt Een Bladwijzer Erbij

### DIFF
--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -19,35 +19,66 @@ const createQuoteMenu = async (
   channel: TextBasedChannelFields,
 ) => {
   const emotes = [
-    '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣',
-    '🇦', '🇧', '🇨', '🇩', '🇪', '🇫', '🇬', '🇭', '🇮', '🇯', '🇰', '🇱', '🇲', '🇳', '🇴', '🇵', '🇶', '🇷', '🇸', '🇹', '🇺', '🇻', '🇼', 'x', 'y', '🇿',
+    '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣',
   ];
-  const title = '**Kiest U maar**\n';
+  const pageLeft = '◀️';
+  const pageRight = '▶️';
 
-  const quoteList = quotes.getItems().map((q, index) => `${emotes[index]} \`${q.text}\``).join('\n');
+  const title = '**Kiest U maar**';
+  const quoteList = quotes.getItems();
+  let page = 0;
 
-  const message = await channel.send(title + quoteList);
-  quotes.getItems().forEach((q, i) => message.react(emotes[i]));
+  const generateText = () => {
+    let text = title;
+
+    for (let i = 0; i < emotes.length; i += 1) {
+      const quote = quoteList[i + page * emotes.length];
+      if (quote) text += `\n${emotes[i]} \`${quote.text}\``;
+    }
+
+    const pageText = `\n\n> \`${page + 1}/${Math.floor(quoteList.length / emotes.length) + 1}\``;
+
+    return text + pageText;
+  };
+
+  const message = await channel.send(generateText());
+  if (quoteList.length > emotes.length) {
+    message.react(pageLeft);
+    message.react(pageRight);
+  }
+  quoteList.forEach((q, i) => { if (i <= 4) message.react(emotes[i]); });
 
   // eslint-disable-next-line max-len
-  const filter : CollectorFilter = (reaction : MessageReaction, user : DiscordUser) => emotes.some((e) => e === reaction.emoji.name) && user.id === owner.id;
-  const collector = message.createReactionCollector(filter, { max: 1 });
+  const filter : CollectorFilter = (r : MessageReaction, u : DiscordUser) => (emotes.some((e) => e === r.emoji.name) || r.emoji.name === pageLeft || r.emoji.name === pageRight) && u.id === owner.id;
+  const collector = message.createReactionCollector(filter);
 
   const timeout = setTimeout(() => {
     collector.stop();
     message.delete().catch(console.error);
   }, 60 * 1000);
 
-  collector.on('collect', (r) => {
+  collector.on('collect', (r, u) => {
     const i = emotes.findIndex((e) => e === r.emoji.name);
-    const quote = quotes[i];
+    const quote = quotes[i + page * emotes.length];
 
-    if (quote) { sendQuote(channel, quotes[i], quotedUser); } else {
-      channel.send('?');
+    if (quote && i !== -1) {
+      sendQuote(channel, quote, quotedUser);
+
+      message.delete();
+      collector.stop();
+
+      clearTimeout(timeout);
     }
-    message.delete();
+    if (r.emoji.name === pageLeft || r.emoji.name === pageRight) {
+      if (r.emoji.name === pageLeft && page > 0) page -= 1;
+      if (r.emoji.name === pageRight && page < Math.floor(quoteList.length / emotes.length)) {
+        page += 1;
+      }
 
-    clearTimeout(timeout);
+      r.users.remove(u);
+
+      message.edit(generateText());
+    }
   });
 };
 

--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -71,6 +71,8 @@ const createQuoteMenu = async (
     const i = emotes.findIndex((e) => e === r.emoji.name);
     const quote = quotes[i + page * emotes.length];
 
+    r.users.remove(u);
+
     if (quote && i !== -1) {
       sendQuote(channel, quote, quotedUser);
 
@@ -85,8 +87,6 @@ const createQuoteMenu = async (
       if (r.emoji.name === pageRight && page < Math.floor(quoteList.length / emotes.length)) {
         page += 1;
       }
-
-      r.users.remove(u);
 
       message.edit(generateText());
 

--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -71,7 +71,7 @@ const createQuoteMenu = async (
     const i = emotes.findIndex((e) => e === r.emoji.name);
     const quote = quotes[i + page * emotes.length];
 
-    r.users.remove(u);
+    r.users.remove(u).catch();
 
     if (quote && i !== -1) {
       sendQuote(channel, quote, quotedUser);


### PR DESCRIPTION
**Changelog**:
```markdown
*Toegevoegd:* Het quote-menu is nu opgedeeld in pagina's

>>> *Next Up: Het verwijderen van quotes*
Mijn idee is dat je de quotes die jij hebt aangemaakt en quotes die op jou naam staan kan verwijderen. 
Admins krijgen een apart kanaal waar de bot alle quotes laat zien in aparte berichten. Een admin kan een actie op dat bericht uitvoeren om de quote te verwijderen (waarschijnlijk door het bericht te verwijderen).
```

[Bij het squashen en mergen van de pull request haal (#nummer) uit de message en paste de changelog in de body]
