### PR TITLE
Quote Make-Over (Router Redesign)

### DIFF
--- a/src/EiNoah.ts
+++ b/src/EiNoah.ts
@@ -59,7 +59,16 @@ class EiNoah {
 
           messageParser(msg, em).then((info) => {
             this.router.handle(info)
-              .then(() => em.flush())
+              .then(async (response) => {
+                if (response) {
+                  if (typeof (response) !== 'string') {
+                    await msg.channel.send(response);
+                  } else {
+                    await msg.channel.send(response, { split: true });
+                  }
+                }
+                await em.flush();
+              })
               .catch(async (err : Error) => {
                 if (process.env.NODE_ENV !== 'production') {
                 // Error message in development

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -8,6 +8,8 @@ import {
   NewsChannel,
   Guild,
   MessageOptions,
+  StringResolvable,
+  MessageAdditions,
 } from 'discord.js';
 import {
   EntityManager, MikroORM, IDatabaseDriver, Connection,
@@ -27,7 +29,8 @@ export interface RouteInfo {
   category: Category | null,
   em: EntityManager
 }
-export type HandlerReturn = MessageOptions | string | null;
+export type HandlerReturn =
+  (MessageOptions & {content: StringResolvable}) | MessageAdditions | string | null;
 
 export interface Handler {
   (info: RouteInfo) : HandlerReturn | Promise<HandlerReturn>

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -7,6 +7,7 @@ import {
   TextChannel,
   NewsChannel,
   Guild,
+  MessageOptions,
 } from 'discord.js';
 import {
   EntityManager, MikroORM, IDatabaseDriver, Connection,
@@ -26,9 +27,10 @@ export interface RouteInfo {
   category: Category | null,
   em: EntityManager
 }
+export type HandlerReturn = MessageOptions | string | null;
 
 export interface Handler {
-  (info: RouteInfo) : void | Promise<void>
+  (info: RouteInfo) : HandlerReturn | Promise<HandlerReturn>
 }
 
 export interface RouteList {
@@ -153,7 +155,7 @@ export default class Router {
 
   // INTERNAL
   // Zorgt dat de commando's op de goede plek terecht komen
-  public handle(info: RouteInfo) : Promise<void> {
+  public handle(info: RouteInfo) : Promise<HandlerReturn> {
     return new Promise((resolve, reject) => {
       const currentRoute = info.params[0];
 
@@ -194,7 +196,7 @@ export default class Router {
           try {
             const handling = handler(newInfo);
             if (handling instanceof Promise) handling.then(resolve).catch(reject);
-            else resolve();
+            else resolve(handling);
           } catch (err) {
             reject(err);
           }

--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -2,7 +2,9 @@ import {
   CollectorFilter, MessageReaction, TextBasedChannelFields, User as DiscordUser,
 } from 'discord.js';
 
-export type ButtonReturn = boolean | Promise<boolean> | void | Promise<void>;
+export type ButtonReturn = boolean | Promise<boolean>
+| void | Promise<void>
+| string | Promise<string>;
 
 export type ExtraButton = [string, () => ButtonReturn];
 

--- a/src/entity/Quote.ts
+++ b/src/entity/Quote.ts
@@ -7,7 +7,7 @@ import { GuildUser } from './GuildUser';
 @Entity()
 class Quote {
   @PrimaryKey({ serializedPrimaryKey: true })
-  private id!: number;
+  id!: number;
 
   @ManyToOne({ eager: true })
   guildUser!: GuildUser;
@@ -18,9 +18,13 @@ class Quote {
   @Property()
   text!: string;
 
+  @Property()
+  date?: Date;
+
   constructor(text : string, creator: GuildUser) {
     this.text = text;
     this.creator = creator;
+    this.date = new Date();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,31 +25,29 @@ eiNoah.use('bday', Birthday);
 // Dit is waar berichten worden afgehandeld
 eiNoah.use('steek', (routeInfo) => {
   if (routeInfo.params[0] instanceof User) {
-    routeInfo.msg.channel.send(`Met plezier, kom hier <@!${(routeInfo.params[0]).id}>!`);
-  } else {
-    routeInfo.msg.channel.send('Lekker');
+    return `Met plezier, kom hier <@!${(routeInfo.params[0]).id}>!`;
   }
+  return 'Lekker';
 });
 
-eiNoah.use(Role, ({ msg, params }) => {
-  msg.channel.send(`${params[0]}s zijn gamers`);
-});
+eiNoah.use(Role, ({ params }) => `${params[0]}s zijn gamers`);
 
 // Als een mention als parameter is gebruikt wordt deze functie aangeroepen,
 // je kan hiervoor geen Router gebruiken
 eiNoah.use(User, (routeInfo) => {
-  if (routeInfo.params[0] instanceof User) routeInfo.msg.channel.send(`What about ${routeInfo.params[0]}`);
+  if (routeInfo.params[0] instanceof User) return `What about ${routeInfo.params[0]}`;
+  return null;
 });
 
 // Voorbeeld hoe je met user data omgaat
 if (process.env.NODE_ENV !== 'production') eiNoah.use('counter', Counter);
 
-eiNoah.use(null, (info) => {
+eiNoah.use(null, () => {
   const watZegtNoah = ['Ja wat jonge', '**Kabaal** ik zit op de fiets', 'Ik steek je neer', 'Hmm wat zegt noah nog meer', 'Ik laat het aan god over'];
 
   const zeg = watZegtNoah[Math.floor(Math.random() * watZegtNoah.length)];
 
-  info.msg.channel.send(zeg);
+  return zeg;
 });
 
 eiNoah.use('quote', QuoteRouter);

--- a/src/migrations/Migration20210120213934.ts
+++ b/src/migrations/Migration20210120213934.ts
@@ -1,0 +1,9 @@
+import { Migration } from 'mikro-orm';
+
+export class Migration20210120213934 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "quote" add column "date" timestamptz(0) null;');
+  }
+
+}

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -11,7 +11,7 @@ const options : Options = {
   type: 'postgresql', // one of `mongo` | `mysql` | `mariadb` | `postgresql` | `sqlite`
   host: process.env.HOST || 'localhost',
   password: process.env.PASSWORD || undefined,
-  user: 'ei-noah',
+  user: process.env.DBUSER || 'ei-noah',
   migrations: {
     tableName: 'mikro_orm_migrations',
     path: './src/migrations',

--- a/src/routes/Birthday.ts
+++ b/src/routes/Birthday.ts
@@ -52,7 +52,14 @@ router.use('show-all', async ({ msg, em }) => {
   let message = 'Hier zijn alle verjaardagen die zijn geregistreerd: ';
   const users = await em.find(User, { $not: { birthday: null } });
   const discUsers = await Promise.all(users.map((u) => msg.client.users.fetch(u.id, true)));
-  discUsers.forEach((du) => { message += `\n${du.username} is geboren op ${moment(users.find((u) => u.id === du.id)?.birthday).locale('nl').format('DD MMMM YYYY')}`; });
+  discUsers
+    .sort((a, b) => {
+      const momentA = moment(users.find((u) => u.id === a.id)?.birthday);
+      const momentB = moment(users.find((u) => u.id === b.id)?.birthday);
+
+      return momentA.dayOfYear() - momentB.dayOfYear();
+    })
+    .forEach((du) => { message += `\n${du.username} is geboren op ${moment(users.find((u) => u.id === du.id)?.birthday).locale('nl').format('DD MMMM YYYY')}`; });
 
   return message;
 });

--- a/src/routes/CoronaRouter.ts
+++ b/src/routes/CoronaRouter.ts
@@ -242,7 +242,9 @@ router.onInit = async (client, orm) => {
     });
   };
 
-  refreshData();
+  if (process.env.REFRESH_DATA?.toLowerCase() !== 'false') {
+    refreshData();
+  }
 
   const reportCron = new CronJob('0 9 * * *', postReport);
 

--- a/src/routes/CoronaRouter.ts
+++ b/src/routes/CoronaRouter.ts
@@ -8,25 +8,24 @@ import CoronaData, { CoronaInfo } from '../entity/CoronaData';
 
 const router = new Router();
 
-const helpHandler : Handler = ({ msg }) => {
+const helpHandler : Handler = () => {
   let message = '**Krijg iedere morgen een rapportage over de locale corona situatie**';
   message += '\nMogelijke Commandos:';
   message += '\n`ei corona regions`: Vraag alle mogelijke regio\'s op';
   message += '\n`ei corona add <regio>`: Voeg een regio toe aan je dagelijkse rapportage';
   message += '\n`ei corona remove <regio>`: Verwijder een regio van je dagelijkse rapportage';
 
-  msg.channel.send(message);
+  return message;
 };
 
 router.use(null, helpHandler);
 router.use('help', helpHandler);
 
 const addHandler : Handler = async ({
-  msg, user, params, em,
+  user, params, em,
 }) => {
   if (!params.every((param) : param is string => typeof param === 'string')) {
-    msg.channel.send('Jij denkt dat een persoon een regio is?');
-    return;
+    return 'Jij denkt dat een persoon een regio is?';
   }
 
   const region = params.filter((param) : param is string => typeof param === 'string').join(' ');
@@ -35,16 +34,14 @@ const addHandler : Handler = async ({
     .find((r) => r.region.toLowerCase() === region.toLowerCase());
 
   if (currentRegions) {
-    msg.channel.send('Deze regio is al toegevoegd');
-    return;
+    return 'Deze regio is al toegevoegd';
   }
 
   const coronaReport = (await em.getRepository(CoronaData)
     .findAll({ limit: 500 }))
     .find((cr) => cr.community.toLowerCase() === region.toLowerCase());
   if (!coronaReport) {
-    msg.channel.send(`${region} is niet een regio`);
-    return;
+    return `${region} is niet een regio`;
   }
 
   const newRegion = new UserCoronaRegions();
@@ -54,18 +51,17 @@ const addHandler : Handler = async ({
 
   em.persist(newRegion);
 
-  msg.channel.send(`${coronaReport.community} is toegevoegd aan je dagelijkse rapport`);
+  return `${coronaReport.community} is toegevoegd aan je dagelijkse rapport`;
 };
 
 router.use('add', addHandler);
 router.use('toevoegen', addHandler);
 
 const removeHandler : Handler = async ({
-  msg, user, params, em,
+  user, params, em,
 }) => {
   if (!params.every((param) : param is string => typeof param === 'string')) {
-    msg.channel.send('Jij denkt dat een persoon een regio is?');
-    return;
+    return 'Jij denkt dat een persoon een regio is?';
   }
 
   const region = params.filter((param) : param is string => typeof param === 'string').join(' ');
@@ -74,13 +70,12 @@ const removeHandler : Handler = async ({
     .find((r) => r.region.toLowerCase() === region.toLowerCase());
 
   if (!dbRegion) {
-    msg.channel.send('Je hebt deze regio nog niet toegevoegd');
-    return;
+    return 'Je hebt deze regio nog niet toegevoegd';
   }
 
   em.removeEntity(dbRegion);
 
-  msg.channel.send(`${dbRegion.region} is verwijderd van je dagelijkse rapport`);
+  return `${dbRegion.region} is verwijderd van je dagelijkse rapport`;
 };
 
 router.use('remove', removeHandler);
@@ -93,8 +88,10 @@ const listRegionsHandler : Handler = async ({ msg, em }) => {
   const regions = Array.from(new Set<string>(coronaData.map((data) => data.community)))
     .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
-  if (regions.length === 0) msg.channel.send('Regio\'s zijn nog niet geladen (dit kan nog 10 minuten duren)');
-  else msg.author.send(`Regio's:\n${regions.join('\n')}`, { split: true });
+  if (regions.length === 0) return 'Regio\'s zijn nog niet geladen (dit kan nog 10 minuten duren)';
+
+  msg.author.send(`Regio's:\n${regions.join('\n')}`, { split: true });
+  return null;
 };
 
 router.use('gemeentes', listRegionsHandler);

--- a/src/routes/Counter.ts
+++ b/src/routes/Counter.ts
@@ -7,22 +7,16 @@ router.use('add', async ({ msg, guildUser }) => {
   // kan undefined behaviour veroorzaken
 
   if (guildUser == null) {
-    msg.channel.send('Alleen gebruiken in een server');
-    return;
+    return 'Alleen gebruiken in een server';
   }
   const data = guildUser;
 
   if (!data.user.count) data.user.count = 1;
   else data.user.count += 1;
 
-  msg.channel.send(`${msg.author.tag} has counted to ${data.user.count}`);
+  return `${msg.author.tag} has counted to ${data.user.count}`;
 });
 
-router.use('get', async ({ msg, guildUser }) => {
-  msg.channel.send(`${msg.author.tag} is now on ${guildUser?.user.count}`);
-
-  // Geen data aangepast
-  // Niks opslaan
-});
+router.use('get', async ({ msg, guildUser }) => `${msg.author.tag} is now on ${guildUser?.user.count}`);
 
 export default router;

--- a/src/routes/LobbyRouter.ts
+++ b/src/routes/LobbyRouter.ts
@@ -135,68 +135,68 @@ const createHandler : Handler = async ({
     || msg.channel instanceof NewsChannel
     || msg.guild === null
     || guildUser === null) {
-    msg.channel.send('Je kan alleen lobbies aanmaken op een server');
-  } else if (!category || !category.isLobbyCategory || msg.channel.parentID === null) {
-    msg.channel.send('Je mag geen lobbies aanmaken in deze categorie');
-  } else if (nonUsersAndRoles.length) {
-    msg.channel.send('Alleen mentions mogelijk als argument(en)');
-  } else {
-    const activeChannel = await activeTempChannel(guildUser, msg.client);
+    return 'Je kan alleen lobbies aanmaken op een server';
+  } if (!category || !category.isLobbyCategory || msg.channel.parentID === null) {
+    return 'Je mag geen lobbies aanmaken in deze categorie';
+  } if (nonUsersAndRoles.length) {
+    return 'Alleen mentions mogelijk als argument(en)';
+  }
+  const activeChannel = await activeTempChannel(guildUser, msg.client);
 
-    let type = ChannelType.Mute;
-    if (flags.some((flag) => flag.toLowerCase() === ChannelType.Mute)) type = ChannelType.Mute;
-    else if (flags.some((flag) => flag.toLowerCase() === ChannelType.Public)) {
-      type = ChannelType.Public;
-    } else if (flags.some((flag) => flag.toLowerCase() === ChannelType.Nojoin)) {
-      type = ChannelType.Nojoin;
-    }
+  let type = ChannelType.Mute;
+  if (flags.some((flag) => flag.toLowerCase() === ChannelType.Mute)) type = ChannelType.Mute;
+  else if (flags.some((flag) => flag.toLowerCase() === ChannelType.Public)) {
+    type = ChannelType.Public;
+  } else if (flags.some((flag) => flag.toLowerCase() === ChannelType.Nojoin)) {
+    type = ChannelType.Nojoin;
+  }
 
-    let userLimit = flags
-      .map((flag) => Number.parseInt(flag, 10))
-      .find((flag) => Number.isSafeInteger(flag));
+  let userLimit = flags
+    .map((flag) => Number.parseInt(flag, 10))
+    .find((flag) => Number.isSafeInteger(flag));
 
-    if (userLimit === undefined) {
-      userLimit = 0;
-    } else if (userLimit < 0) {
-      userLimit = 0;
-    } else if (userLimit > 99) {
-      userLimit = 99;
-    }
+  if (userLimit === undefined) {
+    userLimit = 0;
+  } else if (userLimit < 0) {
+    userLimit = 0;
+  } else if (userLimit > 99) {
+    userLimit = 99;
+  }
 
-    if (activeChannel) {
-      msg.channel.send('Je hebt al een lobby');
-    } else {
-      try {
-        const createdChannel = await createTempChannel(
-          msg.guild,
-          msg.channel.parentID,
-          invited,
-          msg.author,
-          guildUser.guild.bitrate,
-          type,
-          userLimit,
-        );
+  if (activeChannel) {
+    return 'Je hebt al een lobby';
+  }
+  try {
+    const createdChannel = await createTempChannel(
+      msg.guild,
+      msg.channel.parentID,
+      invited,
+      msg.author,
+      guildUser.guild.bitrate,
+      type,
+      userLimit,
+    );
 
-        const gu = guildUser;
+    const gu = guildUser;
 
-        gu.tempChannel = createdChannel.id;
-        gu.tempCreatedAt = new Date();
+    gu.tempChannel = createdChannel.id;
+    gu.tempCreatedAt = new Date();
 
-        if (invited.length > 0) {
-          msg.channel.send(`Lobby aangemaakt voor ${invited.map((user) => (user instanceof DiscordUser ? user.username : `${user.name}s`)).join(', ')} en jij`);
-        } else msg.channel.send('Lobby aangemaakt');
-      } catch (err) {
-        if (err instanceof DiscordAPIError) {
-          if (err.code === Constants.APIErrors.INVALID_FORM_BODY) {
-            msg.channel.send('Neem contact op met de server admins, waarschijnlijk staat de bitrate voor de lobbies te hoog');
-          }
-        } else {
-          console.error(err);
-          msg.channel.send('Onverwachte error');
-        }
+    if (invited.length > 0) {
+      return `Lobby aangemaakt voor ${invited.map((user) => (user instanceof DiscordUser ? user.username : `${user.name}s`)).join(', ')} en jij`;
+    } return 'Lobby aangemaakt';
+  } catch (err) {
+    if (err instanceof DiscordAPIError) {
+      if (err.code === Constants.APIErrors.INVALID_FORM_BODY) {
+        return 'Neem contact op met de server admins, waarschijnlijk staat de bitrate voor de lobbies te hoog';
       }
+    } else {
+      console.error(err);
+      return 'Onverwachte error';
     }
   }
+
+  return 'Er is iets fout gegaan, als je dit bericht ziet stuur een dm naar een ei-noah dev';
 };
 
 // ei lobby create ...
@@ -210,8 +210,7 @@ createRouter.use(null, createHandler);
 
 router.use('add', async ({ params, msg, guildUser }) => {
   if (msg.channel instanceof DMChannel || guildUser === null) {
-    msg.channel.send('Dit commando kan alleen gebruikt worden op een server');
-    return;
+    return 'Dit commando kan alleen gebruikt worden op een server';
   }
 
   const nonUserOrRole = params
@@ -221,20 +220,17 @@ router.use('add', async ({ params, msg, guildUser }) => {
     .filter((param): param is DiscordUser | Role => param instanceof DiscordUser || param instanceof Role);
 
   if (nonUserOrRole.length > 0) {
-    msg.channel.send('Alleen user mention(s) mogelijk als argument');
-    return;
+    return ('Alleen user mention(s) mogelijk als argument');
   }
 
   const activeChannel = await activeTempChannel(guildUser, msg.client);
 
   if (!activeChannel) {
-    msg.channel.send('Je hebt nog geen lobby aangemaakt\nMaak deze aan met `ei lobby create`');
-    return;
+    return 'Je hebt nog geen lobby aangemaakt\nMaak deze aan met `ei lobby create`';
   }
 
   if (activeChannel.parentID !== msg.channel.parentID) {
-    msg.channel.send('Je lobby is aanwezig in een andere categorie dan deze');
-    return;
+    return 'Je lobby is aanwezig in een andere categorie dan deze';
   }
 
   const allowedUsers : Array<DiscordUser | Role> = [];
@@ -268,7 +264,7 @@ router.use('add', async ({ params, msg, guildUser }) => {
   if (!alreadyAllowedUsers.length) alreadyInMessage = '';
   else alreadyInMessage = `${alreadyAllowedUsers.map((user) => (user instanceof DiscordUser ? user.username : `${user.name}s`)).join(', ')} ${alreadyAllowedUsers.length > 1 || allowedUsers.some((user) => user instanceof Role) ? 'konden' : 'kon'} al naar binnen`;
 
-  msg.channel.send(`${allowedUsersMessage}\n${alreadyInMessage}`);
+  return `${allowedUsersMessage}\n${alreadyInMessage}`;
 });
 
 const removeFromLobby = (
@@ -363,8 +359,7 @@ const removeFromLobby = (
 
 router.use('remove', async ({ params, msg, guildUser }) => {
   if (msg.channel instanceof DMChannel || guildUser === null || msg.guild == null) {
-    msg.channel.send('Dit commando kan alleen gebruikt worden op een server');
-    return;
+    return 'Dit commando kan alleen gebruikt worden op een server';
   }
 
   const nonUsersOrRoles = params
@@ -373,25 +368,21 @@ router.use('remove', async ({ params, msg, guildUser }) => {
   const roles = params.filter((param): param is Role => param instanceof Role);
 
   if (nonUsersOrRoles.length > 0) {
-    msg.channel.send('Alleen mention(s) mogelijk als argument');
-    return;
+    return 'Alleen mention(s) mogelijk als argument';
   }
 
   const activeChannel = await activeTempChannel(guildUser, msg.client);
 
   if (!activeChannel) {
-    msg.channel.send('Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`');
-    return;
+    return 'Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`';
   }
 
   if (activeChannel.parentID !== msg.channel.parentID) {
-    msg.channel.send('Je lobby is aanwezig in een andere categorie dan deze');
-    return;
+    return 'Je lobby is aanwezig in een andere categorie dan deze';
   }
 
   if (getChannelType(activeChannel) === ChannelType.Public) {
-    msg.channel.send('Wat snap jij niet aan een **public** lobby smeerjoch');
-    return;
+    return 'Wat snap jij niet aan een **public** lobby smeerjoch';
   }
 
   if (params.length === 0) {
@@ -410,8 +401,7 @@ router.use('remove', async ({ params, msg, guildUser }) => {
       .map((member) => member.user);
 
     if (removeAbleUsers.length === 0 && removeAbleRoles.length === 0) {
-      msg.channel.send('Geen gebruikers of roles die verwijderd kunnen worden');
-      return;
+      return 'Geen gebruikers of roles die verwijderd kunnen worden';
     }
 
     const selectedUsers = new Set<DiscordUser>();
@@ -441,57 +431,49 @@ router.use('remove', async ({ params, msg, guildUser }) => {
           msg.channel,
           msg.author);
       }]);
-
-    return;
   }
 
   removeFromLobby(activeChannel, users, roles, msg.channel, msg.author);
+  return null;
 });
 
 const changeTypeHandler : Handler = async ({ params, msg, guildUser }) => {
   if (msg.channel instanceof DMChannel || msg.guild === null || guildUser === null) {
-    msg.channel.send('Dit commando kan alleen op servers worden gebruikt');
-    return;
+    return 'Dit commando kan alleen op servers worden gebruikt';
   }
   const activeChannel = await activeTempChannel(guildUser, msg.client);
 
   if (!activeChannel) {
-    msg.channel.send('Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`');
-    return;
+    return 'Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`';
   }
 
   if (activeChannel.parentID !== msg.channel.parentID) {
-    msg.channel.send('Je lobby is aanwezig in een andere categorie dan deze');
-    return;
+    return 'Je lobby is aanwezig in een andere categorie dan deze';
   }
 
   if (params.length > 1) {
-    msg.channel.send('Ik verwachte niet meer dan **één** argument');
-    return;
+    return 'Ik verwachte niet meer dan **één** argument';
   }
 
   const type = getChannelType(activeChannel);
 
   if (params.length !== 1) {
-    if (type === ChannelType.Mute) msg.channel.send(`Type van lobby is \`${ChannelType.Mute}\` andere types zijn \`${ChannelType.Public}\` en \`${ChannelType.Nojoin}\``);
-    else if (type === ChannelType.Nojoin) msg.channel.send(`Type van lobby is \`${ChannelType.Nojoin}\` andere types zijn \`${ChannelType.Public}\` en \`${ChannelType.Mute}\``);
-    else msg.channel.send(`Type van lobby is \`${ChannelType.Public}\` andere types zijn \`${ChannelType.Mute}\` en \`${ChannelType.Nojoin}\``);
-  } else if (params.length === 1) {
+    if (type === ChannelType.Mute) return `Type van lobby is \`${ChannelType.Mute}\` andere types zijn \`${ChannelType.Public}\` en \`${ChannelType.Nojoin}\``;
+    if (type === ChannelType.Nojoin) return `Type van lobby is \`${ChannelType.Nojoin}\` andere types zijn \`${ChannelType.Public}\` en \`${ChannelType.Mute}\``;
+    return `Type van lobby is \`${ChannelType.Public}\` andere types zijn \`${ChannelType.Mute}\` en \`${ChannelType.Nojoin}\``;
+  } if (params.length === 1) {
     if (typeof params[0] !== 'string') {
-      msg.channel.send('Ik verwachte hier geen **mention**');
-      return;
+      return 'Ik verwachte hier geen **mention**';
     }
 
     const [changeTo] = <ChannelType[]>params;
 
     if (!Object.values(ChannelType).includes(changeTo)) {
-      msg.channel.send(`*${params[0]}* is niet een lobby type`);
-      return;
+      return `*${params[0]}* is niet een lobby type`;
     }
 
     if (changeTo === type) {
-      msg.channel.send(`Je lobby was al een **${type}** lobby`);
-      return;
+      return `Je lobby was al een **${type}** lobby`;
     }
 
     const deny = toDeny(changeTo);
@@ -517,11 +499,13 @@ const changeTypeHandler : Handler = async ({ params, msg, guildUser }) => {
       ...activeChannel.permissionOverwrites.array(),
       { id: msg.guild.id, deny },
       ...newOverwrites,
-    ]).then((channel) => {
-      channel.setName(generateLobbyName(changeTo, msg.author)).catch((err) => console.error('Change name error', err));
-      msg.channel.send(`Lobby type is veranderd naar *${changeTo}*`).catch((err) => console.error('Send message error', err));
-    }).catch((err) => console.error('Overwrite error', err));
+    ]).catch(console.error);
+
+    activeChannel.setName(generateLobbyName(changeTo, msg.author)).catch((err) => console.error('Change name error', err));
+    return `Lobby type is veranderd naar *${changeTo}*`;
   }
+
+  return 'Stuur een berichtje naar een ei-noah dev als je dit bericht ziet';
 };
 
 router.use('type', changeTypeHandler);
@@ -533,42 +517,35 @@ const sizeHandler : Handler = async ({
   msg, category, guildUser, params,
 }) => {
   if (msg.channel instanceof DMChannel || guildUser === null) {
-    msg.channel.send('Je kan dit commando alleen op servers gebruiken');
-    return;
+    return 'Je kan dit commando alleen op servers gebruiken';
   }
 
   if (!category || !category.isLobbyCategory) {
-    msg.channel.send('Dit is geen lobby category');
-    return;
+    return 'Dit is geen lobby category';
   }
 
   const activeChannel = await activeTempChannel(guildUser, msg.client);
 
   if (!activeChannel) {
-    msg.channel.send('Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`');
-    return;
+    return 'Je hebt nog geen lobby aangemaakt\nMaak één aan met `ei lobby create`';
   }
 
   if (activeChannel.parentID !== msg.channel.parentID) {
-    msg.channel.send('Je lobby is aanwezig in een andere categorie dan deze');
-    return;
+    return 'Je lobby is aanwezig in een andere categorie dan deze';
   }
 
   if (params.length === 0) {
-    msg.channel.send('Geen één (1) argument gegeven');
-    return;
+    return 'Geen één (1) argument gegeven';
   }
 
   if (params.length > 1) {
-    msg.channel.send('Ik verwachte maar één (1) argument');
-    return;
+    return 'Ik verwachte maar één (1) argument';
   }
 
   const sizeParam = params[0];
 
   if (typeof sizeParam !== 'string') {
-    msg.channel.send('Lijkt dat op een nummer??');
-    return;
+    return 'Lijkt dat op een nummer??';
   }
 
   let size = Number.parseInt(sizeParam, 10);
@@ -578,8 +555,7 @@ const sizeHandler : Handler = async ({
   }
 
   if (!Number.isSafeInteger(size)) {
-    msg.channel.send('Even een normaal nummer alstublieft');
-    return;
+    return 'Even een normaal nummer alstublieft';
   }
 
   if (size > 99) { size = 99; }
@@ -587,7 +563,7 @@ const sizeHandler : Handler = async ({
 
   await activeChannel.setUserLimit(size);
 
-  if (size === 0) { await msg.channel.send('Limiet is verwijderd'); } else msg.channel.send(`Limiet veranderd naar ${size}`);
+  if (size === 0) { return 'Limiet is verwijderd'; } return `Limiet veranderd naar ${size}`;
 };
 
 router.use('size', sizeHandler);
@@ -597,34 +573,28 @@ router.use('userlimit', sizeHandler);
 router.use('category', async ({ category, params, msg }) => {
   const ca = category;
   if (msg.channel instanceof DMChannel) {
-    msg.channel.send('Je kan dit commando alleen op servers gebruiken');
-    return;
+    return 'Je kan dit commando alleen op servers gebruiken';
   }
 
   if (params.length === 0) {
-    if (category && category.isLobbyCategory) msg.channel.send('Je mag lobbies aanmaken in deze categorie');
-    else msg.channel.send('Je mag geen lobbies aanmaken in deze categorie');
-    return;
+    if (category && category.isLobbyCategory) return 'Je mag lobbies aanmaken in deze categorie';
+    return 'Je mag geen lobbies aanmaken in deze categorie';
   }
 
   if (params.length > 1) {
-    msg.channel.send('Ik verwacht maar één argument');
-    return;
+    return 'Ik verwacht maar één argument';
   }
 
   if (typeof params[0] !== 'string') {
-    msg.channel.send('Ik verwacht een string als argument');
-    return;
+    return 'Ik verwacht een string als argument';
   }
 
   if (!msg.member?.hasPermission('ADMINISTRATOR')) {
-    msg.channel.send('Alleen een Edwin mag dit aanpassen');
-    return;
+    return 'Alleen een Edwin mag dit aanpassen';
   }
 
   if (!category) {
-    msg.channel.send('Dit kanaal zit niet in een categorie');
-    return;
+    return 'Dit kanaal zit niet in een categorie';
   }
 
   let isAllowed : boolean;
@@ -632,63 +602,56 @@ router.use('category', async ({ category, params, msg }) => {
   if (params[0].toLowerCase() === 'true' || params[0] === '1') isAllowed = true;
   else if (params[0].toLowerCase() === 'false' || params[0] === '0') isAllowed = false;
   else {
-    msg.channel.send(`\`${params[0]}\` is niet een argument, verwacht \`true\` of \`false\``);
-    return;
+    return `\`${params[0]}\` is niet een argument, verwacht \`true\` of \`false\``;
   }
 
-  msg.channel.send(isAllowed ? 'Users kunnen nu lobbies aanmaken in deze category' : 'User kunnen nu geen lobbies meer aanmaken in deze category');
-
   if (ca) { ca.isLobbyCategory = isAllowed; }
+
+  return isAllowed ? 'Users kunnen nu lobbies aanmaken in deze category' : 'User kunnen nu geen lobbies meer aanmaken in deze category';
 });
 
 router.use('bitrate', async ({ msg, guildUser, params }) => {
   if (msg.channel instanceof DMChannel || guildUser === null) {
-    msg.channel.send('Je kan dit commando alleen op servers gebruiken');
-    return;
+    return 'Je kan dit commando alleen op servers gebruiken';
   }
 
   if (params.length === 0) {
-    msg.channel.send(`Lobby bitrate is ${guildUser.guild.bitrate}`);
-    return;
+    return `Lobby bitrate is ${guildUser.guild.bitrate}`;
   }
 
   if (params.length > 1) {
-    msg.channel.send('Ik verwacht maar één argument');
-    return;
+    return 'Ik verwacht maar één argument';
   }
 
   if (typeof params[0] !== 'string') {
-    msg.channel.send('Ik verwacht een string als argument');
-    return;
+    return 'Ik verwacht een string als argument';
   }
 
   if (!msg.member?.hasPermission('ADMINISTRATOR')) {
-    msg.channel.send('Alleen een Edwin mag dit aanpassen');
-    return;
+    return 'Alleen een Edwin mag dit aanpassen';
   }
 
   const newBitrate = Number(params[0]);
 
   if (Number.isNaN(newBitrate)) {
-    msg.channel.send(`${params[0]} is niet een nummer`);
-    return;
+    return `${params[0]} is niet een nummer`;
   }
 
   if (newBitrate > 128000) {
-    msg.channel.send('Bitrate gaat tot 128000');
-    return;
+    return 'Bitrate gaat tot 128000';
   }
 
   if (newBitrate < 8000) {
-    msg.channel.send('Bitrate gaat boven 8000');
-    return;
+    return 'Bitrate gaat boven 8000';
   }
 
   // eslint-disable-next-line no-param-reassign
   guildUser.guild.bitrate = newBitrate;
+
+  return `Bitrate veranderd naar ${newBitrate}`;
 });
 
-const helpHanlder : Handler = ({ msg }) => {
+const helpHanlder : Handler = () => {
   let message = '**Maak een tijdelijke voice kanaal aan**';
   message += '\nMogelijke Commandos:';
   message += '\n`ei lobby create [@mention ...]`: Maak een private lobby aan en laat alleen de toegestaande mensen joinen';
@@ -701,7 +664,7 @@ const helpHanlder : Handler = ({ msg }) => {
   message += '\n`ei lobby limit <nummer>`: Verander de lobby user limit';
   message += '\n`*Admin* ei lobby category true/ false`: Sta users toe lobbies aan te maken in deze categorie';
   message += '\n`*Admin* ei lobby bitrate <8000 - 128000>`: Stel in welke bitrate de lobbies hebben wanneer ze worden aangemaakt';
-  msg.channel.send(message);
+  return message;
 };
 
 router.use(null, helpHanlder);

--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -17,7 +17,7 @@ const sendQuote = async (channel : TextBasedChannelFields, quote : Quote, client
 
   text.replace('`', '\\`');
 
-  return `> ${quote.text}\n- ${(await quoted).username} (door ${(await owner).username})`;
+  await channel.send(`> ${quote.text}\n- ${(await quoted).username} (door ${(await owner).username})`);
 };
 
 const handler : Handler = async ({
@@ -56,7 +56,9 @@ const handler : Handler = async ({
       msg.channel,
       '**Kiest U Maar**',
       (q) => q.text,
-      (q) => { sendQuote(msg.channel, q, msg.client); });
+      (q) => {
+        sendQuote(msg.channel, q, msg.client);
+      });
     return null;
   }
 

--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -1,6 +1,6 @@
 import {
   Client,
-  DMChannel, Permissions, TextBasedChannelFields, User as DiscordUser,
+  DMChannel, MessageEmbed, Permissions, TextBasedChannelFields, TextChannel, User as DiscordUser,
 } from 'discord.js';
 import createMenu from '../createMenu';
 import Quote from '../entity/Quote';
@@ -13,11 +13,21 @@ const sendQuote = async (channel : TextBasedChannelFields, quote : Quote, client
   const quoted = client.users.fetch(quote.guildUser.user.id, true);
   const owner = client.users.fetch(quote.creator.user.id, true);
 
-  const { text } = quote;
+  const text = quote.text.replace('`', '\\`');
 
-  text.replace('`', '\\`');
+  const embed = new MessageEmbed();
 
-  await channel.send(`> ${quote.text}\n- ${(await quoted).username} (door ${(await owner).username})`);
+  const avatarURL = (await quoted).avatarURL() || undefined;
+  let color : number | undefined;
+  if (channel instanceof TextChannel) color = channel.guild.me?.displayColor;
+
+  embed.setAuthor((await quoted).username, avatarURL);
+  embed.setDescription(text);
+  embed.setFooter(`Door ${(await owner).username}`);
+  if (quote.date) embed.setTimestamp(quote.date);
+  if (color) embed.setColor(color);
+
+  await channel.send(embed);
 };
 
 const handler : Handler = async ({


### PR DESCRIPTION
**Message voor devs:**
Ik heb wat aanpassingen gemaakt aan de Router, je moet nu een string terug geven en die wordt dan laten zien. Of je moet null terugsturen als je geen bericht wil sturen. Dit voorkomt dat je een code pad hebt die geen bericht terug geeft, we hoeven nu ook maar op één plek de message send logica te hebben, ipv elke keer msg.channel.send te hoeven doen

```ts
router.use('gamer', () => 'Dus op deze manier'); // Wat je returnt wordt verzonden
```

**Changelog**:
```md
*Veranderd:* Quotes hebben een make-over gekregen :D
> Los hiervan, wanneer Discord.JS het toelaat kunnen we het ook zo maken dat je op een bericht kan replyen met `ei quote` zodat het bericht een quote wordt

*Veranderd:* Verjaardagen worden nu gesorteerd

*Veranderd:* Onder de zee
> Er zijn onderwater wat aanpassingen gemaakt om ons leven iets makkelijker te maken, maar het kan zijn dat deze aanpassingen wat gesloopt hebben
```