### PR TITLE
Ei Noah Voelt Zijn Vingers Niet Meer

### DIFF
--- a/src/EiNoah.ts
+++ b/src/EiNoah.ts
@@ -165,7 +165,7 @@ class EiNoah {
             return;
           }
 
-          msg.channel.startTyping(10000).catch(() => { });
+          msg.channel.startTyping().catch(() => { });
           const em = orm.em.fork();
 
           messageParser(msg, em)
@@ -183,7 +183,7 @@ class EiNoah {
               return null;
             })
             .finally(() => {
-              msg.channel.stopTyping(true);
+              msg.channel.stopTyping();
               return em.flush();
             })
             .catch((err) => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -120,6 +120,8 @@ export default class Router {
           }
         }
       }
+
+      resolve(null);
     });
   }
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -98,6 +98,8 @@ export default class Router {
             if (param instanceof DiscordUser) return `@${param.username}`;
             return '[UNKNOWN]';
           }).join(' ')}\` moet betekenen`);
+
+          resolve(null);
         } else {
           const newParams = [...info.params];
           newParams.shift();
@@ -120,8 +122,6 @@ export default class Router {
           }
         }
       }
-
-      resolve(null);
     });
   }
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -98,8 +98,6 @@ export default class Router {
             if (param instanceof DiscordUser) return `@${param.username}`;
             return '[UNKNOWN]';
           }).join(' ')}\` moet betekenen`);
-
-          resolve(null);
         } else {
           const newParams = [...info.params];
           newParams.shift();
@@ -121,6 +119,8 @@ export default class Router {
             reject(err);
           }
         }
+      } else {
+        resolve(null);
       }
     });
   }

--- a/src/routes/QuoteRouter.ts
+++ b/src/routes/QuoteRouter.ts
@@ -165,7 +165,7 @@ router.use(null, async ({ msg, em }) => {
 
   const quote = quotes[Math.floor(Math.random() * quotes.length)];
 
-  if (quotes) {
+  if (quote) {
     await sendQuote(msg.channel, quote, msg.client);
     return null;
   }


### PR DESCRIPTION
**Message voor devs:**
Ik snap werkelijk niet waarom die menu's soms breken. Vorige keer dat het gebeurde was omdat de message was wegehaald voordat alle emotes er waren neergezet. Maar daar wacht ik nu op voordat ik het weghaal. Dus ik weet niet of er ergens anders een error zit die niet met emotes te maken hebben die het alsnog kapot maakt somehow. 

**Changelog**:
[Changes die belangrijk zijn voor server members. Graag in dit formaat.]
```md
*Fixed*: Ei Noah bleef voor altijd typen (voor de tweeduizendste keer)
```

[Bij het squashen en mergen van de pull request haal (#nummer) uit de message en paste de changelog in de body]
